### PR TITLE
reorderPositions fix in case of empty additionalSQL

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -36,7 +36,12 @@ func reorderPositions(scope *gorm.Scope) {
 				additionalSQL = append(additionalSQL, "deleted_at IS NULL")
 			}
 
-			var sql = fmt.Sprintf("UPDATE %v SET position = (SELECT COUNT(pos) + 1 FROM (SELECT DISTINCT(position) AS pos FROM %v WHERE %v) AS t2 WHERE t2.pos < %v.position) WHERE %v", table, table, strings.Join(additionalSQL, " AND "), table, strings.Join(additionalSQL, " AND "))
+			var sql string
+			if len(additionalSQL) > 0 {
+				sql = fmt.Sprintf("UPDATE %v SET position = (SELECT COUNT(pos) + 1 FROM (SELECT DISTINCT(position) AS pos FROM %v WHERE %v) AS t2 WHERE t2.pos < %v.position) WHERE %v", table, table, strings.Join(additionalSQL, " AND "), table, strings.Join(additionalSQL, " AND "))
+			} else {
+				sql = fmt.Sprintf("UPDATE %v SET position = (SELECT COUNT(pos) + 1 FROM (SELECT DISTINCT(position) AS pos FROM %v) AS t2 WHERE t2.pos < %v.position)", table, table, table)
+			}
 			if scope.NewDB().Exec(sql, additionalValues...).Error == nil {
 				// Create Publish Event
 				createPublishEvent(scope.DB(), scope.Value)


### PR DESCRIPTION
additionalSQL may be empty if we don't use soft delete and locales. We ended up with invalid SQL in this case
